### PR TITLE
Adding some rule for cpf validation

### DIFF
--- a/cpf.py
+++ b/cpf.py
@@ -9,6 +9,10 @@ def isCpfValid(cpf):
 
     # Remove some unwanted characters
     cpf = re.sub("[^0-9]",'',cpf)
+    
+    # Verify if CPF number is equal
+    if cpf=='00000000000' or cpf=='11111111111' or cpf=='22222222222' or cpf=='33333333333' or cpf=='44444444444' or cpf=='55555555555' or cpf=='66666666666' or cpf=='77777777777' or cpf=='88888888888' or cpf=='99999999999':
+        return False
 
     # Checks if string has 11 characters
     if len(cpf) != 11:


### PR DESCRIPTION
Hello, first thank you very much to share this code.

I think you should add some rules in cpf.py to verify the integrity of cpf number as according to Receita Federal the cpf number must not contain all numbers equals, just like 111.1111.111-11, this number is not accepted for receita federal.
